### PR TITLE
Interpolation data

### DIFF
--- a/cpp/lagrange.cpp
+++ b/cpp/lagrange.cpp
@@ -125,15 +125,8 @@ FiniteElement libtab::create_lagrange(cell::type celltype, int degree,
     }
   }
 
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info;
-  for (int i = 0; i < pt.rows(); ++i)
-  {
-    Eigen::ArrayXd a(1);
-    a(0) = 1;
-    Eigen::ArrayXXd b(1, pt.cols());
-    b.row(0) = pt.row(i);
-    interpolation_info.push_back(std::make_pair(a, b));
-  }
+  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info
+    = std::make_pair(Eigen::MatrixXd::Identity(ndofs, ndofs), pt);
 
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];
@@ -176,15 +169,8 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       pt.row(j) += (geometry.row(k + 1) - geometry.row(0)) * lattice(j, k);
   }
 
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info;
-  for (int i = 0; i < pt.rows(); ++i)
-  {
-    Eigen::ArrayXd a(1);
-    a(0) = 1;
-    Eigen::ArrayXXd b(1, topology.size() - 1);
-    b.row(0) = pt.row(i);
-    interpolation_info.push_back(std::make_pair(a, b));
-  }
+  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info
+    = std::make_pair(Eigen::MatrixXd::Identity(ndofs, ndofs), pt);
 
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];

--- a/cpp/lagrange.cpp
+++ b/cpp/lagrange.cpp
@@ -125,12 +125,12 @@ FiniteElement libtab::create_lagrange(cell::type celltype, int degree,
     }
   }
 
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info;
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info;
   for (int i = 0; i < pt.rows(); ++i)
   {
     Eigen::ArrayXd a(1);
     a(0) = 1;
-    Eigen::ArrayX2d b(1, topology.size() - 1);
+    Eigen::ArrayXXd b(1, pt.cols());
     b.row(0) = pt.row(i);
     interpolation_info.push_back(std::make_pair(a, b));
   }
@@ -176,12 +176,12 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       pt.row(j) += (geometry.row(k + 1) - geometry.row(0)) * lattice(j, k);
   }
 
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info;
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info;
   for (int i = 0; i < pt.rows(); ++i)
   {
     Eigen::ArrayXd a(1);
     a(0) = 1;
-    Eigen::ArrayX2d b(1, topology.size() - 1);
+    Eigen::ArrayXXd b(1, topology.size() - 1);
     b.row(0) = pt.row(i);
     interpolation_info.push_back(std::make_pair(a, b));
   }

--- a/cpp/lagrange.cpp
+++ b/cpp/lagrange.cpp
@@ -125,16 +125,13 @@ FiniteElement libtab::create_lagrange(cell::type celltype, int degree,
     }
   }
 
-  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info
-    = std::make_pair(Eigen::MatrixXd::Identity(ndofs, ndofs), pt);
-
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(
       Eigen::MatrixXd::Identity(ndofs, ndofs), dualmat);
 
   return FiniteElement(name, celltype, degree, {1}, coeffs, entity_dofs,
-                       base_permutations, pt, interpolation_info);
+                       base_permutations, pt, Eigen::MatrixXd::Identity(ndofs, ndofs));
 }
 //-----------------------------------------------------------------------------
 FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
@@ -169,9 +166,6 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       pt.row(j) += (geometry.row(k + 1) - geometry.row(0)) * lattice(j, k);
   }
 
-  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info
-    = std::make_pair(Eigen::MatrixXd::Identity(ndofs, ndofs), pt);
-
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];
 
@@ -186,6 +180,6 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
 
   return FiniteElement(name, celltype, degree, {1}, coeffs, entity_dofs,
-                       base_permutations, pt, interpolation_info);
+                       base_permutations, pt, Eigen::MatrixXd::Identity(ndofs, ndofs));
 }
 //-----------------------------------------------------------------------------

--- a/cpp/lagrange.cpp
+++ b/cpp/lagrange.cpp
@@ -125,13 +125,23 @@ FiniteElement libtab::create_lagrange(cell::type celltype, int degree,
     }
   }
 
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info;
+  for (int i = 0; i < pt.rows(); ++i)
+  {
+    Eigen::ArrayXd a(1);
+    a(0) = 1;
+    Eigen::ArrayX2d b(1, topology.size() - 1);
+    b.row(0) = pt.row(i);
+    interpolation_info.push_back(std::make_pair(a, b));
+  }
+
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(
       Eigen::MatrixXd::Identity(ndofs, ndofs), dualmat);
 
   return FiniteElement(name, celltype, degree, {1}, coeffs, entity_dofs,
-                       base_permutations, pt);
+                       base_permutations, pt, interpolation_info);
 }
 //-----------------------------------------------------------------------------
 FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
@@ -166,6 +176,16 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       pt.row(j) += (geometry.row(k + 1) - geometry.row(0)) * lattice(j, k);
   }
 
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info;
+  for (int i = 0; i < pt.rows(); ++i)
+  {
+    Eigen::ArrayXd a(1);
+    a(0) = 1;
+    Eigen::ArrayX2d b(1, topology.size() - 1);
+    b.row(0) = pt.row(i);
+    interpolation_info.push_back(std::make_pair(a, b));
+  }
+
   // Point evaluation of basis
   Eigen::MatrixXd dualmat = polyset::tabulate(celltype, degree, 0, pt)[0];
 
@@ -180,6 +200,6 @@ FiniteElement libtab::create_dlagrange(cell::type celltype, int degree,
       perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
 
   return FiniteElement(name, celltype, degree, {1}, coeffs, entity_dofs,
-                       base_permutations, pt);
+                       base_permutations, pt, interpolation_info);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -76,11 +76,11 @@ FiniteElement::FiniteElement(
     std::string name, cell::type cell_type, int degree,
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
-    const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points,
-    const Eigen::MatrixXd interpolation_matrix)
-    : _cell_type(cell_type), _degree(degree), _value_shape(value_shape),
-      _coeffs(coeffs), _entity_dofs(entity_dofs),
-      _base_permutations(base_permutations), _points(points), _family_name(name),
+    const std::vector<Eigen::MatrixXd>& base_permutations,
+    const Eigen::ArrayXXd& points, const Eigen::MatrixXd interpolation_matrix)
+    : _cell_type(cell_type), _family_name(name), _degree(degree),
+      _value_shape(value_shape), _coeffs(coeffs), _entity_dofs(entity_dofs),
+      _base_permutations(base_permutations), _points(points),
       _interpolation_matrix(interpolation_matrix)
 {
   // Check that entity dofs add up to total number of dofs

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -76,10 +76,12 @@ FiniteElement::FiniteElement(
     std::string name, cell::type cell_type, int degree,
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
-    const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points)
+    const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points,
+    const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info)
     : _cell_type(cell_type), _degree(degree), _value_shape(value_shape),
       _coeffs(coeffs), _entity_dofs(entity_dofs),
-      _base_permutations(base_permutations), _points(points), _family_name(name)
+      _base_permutations(base_permutations), _points(points), _family_name(name),
+      _interpolation_info(interpolation_info)
 {
   // Check that entity dofs add up to total number of dofs
   int sum = 0;
@@ -113,6 +115,9 @@ const std::vector<int>& FiniteElement::value_shape() const
 int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family_name() const { return _family_name; }
+//-----------------------------------------------------------------------------
+std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>>
+FiniteElement::interpolation_info() const { return _interpolation_info; }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>> FiniteElement::entity_dofs() const
 {

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -77,7 +77,7 @@ FiniteElement::FiniteElement(
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
     const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points,
-    const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info)
+    const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info)
     : _cell_type(cell_type), _degree(degree), _value_shape(value_shape),
       _coeffs(coeffs), _entity_dofs(entity_dofs),
       _base_permutations(base_permutations), _points(points), _family_name(name),
@@ -116,7 +116,7 @@ int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family_name() const { return _family_name; }
 //-----------------------------------------------------------------------------
-std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>>
+std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>>
 FiniteElement::interpolation_info() const { return _interpolation_info; }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>> FiniteElement::entity_dofs() const

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -77,11 +77,11 @@ FiniteElement::FiniteElement(
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
     const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points,
-    const std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info)
+    const Eigen::MatrixXd interpolation_matrix)
     : _cell_type(cell_type), _degree(degree), _value_shape(value_shape),
       _coeffs(coeffs), _entity_dofs(entity_dofs),
       _base_permutations(base_permutations), _points(points), _family_name(name),
-      _interpolation_info(interpolation_info)
+      _interpolation_matrix(interpolation_matrix)
 {
   // Check that entity dofs add up to total number of dofs
   int sum = 0;
@@ -116,8 +116,8 @@ int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family_name() const { return _family_name; }
 //-----------------------------------------------------------------------------
-std::pair<Eigen::MatrixXd, Eigen::ArrayXXd>
-FiniteElement::interpolation_info() const { return _interpolation_info; }
+Eigen::MatrixXd
+FiniteElement::interpolation_matrix() const { return _interpolation_matrix; }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>> FiniteElement::entity_dofs() const
 {

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -77,7 +77,7 @@ FiniteElement::FiniteElement(
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
     const std::vector<Eigen::MatrixXd>& base_permutations, const Eigen::ArrayXXd& points,
-    const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info)
+    const std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info)
     : _cell_type(cell_type), _degree(degree), _value_shape(value_shape),
       _coeffs(coeffs), _entity_dofs(entity_dofs),
       _base_permutations(base_permutations), _points(points), _family_name(name),
@@ -116,7 +116,7 @@ int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family_name() const { return _family_name; }
 //-----------------------------------------------------------------------------
-std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>>
+std::pair<Eigen::MatrixXd, Eigen::ArrayXXd>
 FiniteElement::interpolation_info() const { return _interpolation_info; }
 //-----------------------------------------------------------------------------
 std::vector<std::vector<int>> FiniteElement::entity_dofs() const

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -307,7 +307,11 @@ public:
   /// Experimental, may go away.
   const Eigen::ArrayXXd& points() const;
 
-  /// TODO: Document
+  /// Return the weights and points for interpolation
+  /// To interpolate a function in this finite element, the functions should be
+  /// evaluated at each point. These function values should then be multiplied by
+  /// the weight matrix to give the coefficients of the interpolated function.
+  /// This returns the pair (weight matrix, array of points)
   std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info() const;
 
 private:
@@ -344,13 +348,7 @@ private:
   // The name of the finite element family
   std::string _family_name;
 
-  /// TODO: Document
-  /// For each dof      std::vector<
-  ///                     std::pair<
-  ///   List of weights     Eigen::ArrayXd,
-  ///   List of points      Eigen::ArrayXXd
-  ///                     >
-  ///                   >
+  /// The interpolation weights and points
   std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> _interpolation_info;
 };
 

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -154,7 +154,8 @@ public:
                 const Eigen::ArrayXXd& coeffs,
                 const std::vector<std::vector<int>>& entity_dofs,
                 const std::vector<Eigen::MatrixXd>& base_permutations,
-                const Eigen::ArrayXXd& points);
+                const Eigen::ArrayXXd& points,
+                const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info={});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -305,7 +306,10 @@ public:
   /// Currently for backward compatibility with DOLFINx function interpolation
   /// Experimental, may go away.
   const Eigen::ArrayXXd& points() const;
-  
+
+  /// TODO: Document
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info() const;
+
 private:
   // Cell type
   cell::type _cell_type;
@@ -336,9 +340,18 @@ private:
   // Experimental - currently used for an implementation of "tabulate_dof_coordinates"
   // Most useful for Lagrange. This may change or go away.
   Eigen::ArrayXXd _points;
-  
+
   // The name of the finite element family
   std::string _family_name;
+
+  /// TODO: Document
+  /// For each dof      std::vector<
+  ///                     std::pair<
+  ///   List of weights     Eigen::ArrayXd,
+  ///   List of points      Eigen::ArrayX2d
+  ///                     >
+  ///                   >
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> _interpolation_info;
 };
 
 /// Create an element by name

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -155,7 +155,7 @@ public:
                 const std::vector<std::vector<int>>& entity_dofs,
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
-                const std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info={});
+                const Eigen::MatrixXd interpolation_matrix={});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -307,12 +307,12 @@ public:
   /// Experimental, may go away.
   const Eigen::ArrayXXd& points() const;
 
-  /// Return the weights and points for interpolation
+  /// Return a matrix of weights interpolation
   /// To interpolate a function in this finite element, the functions should be
-  /// evaluated at each point. These function values should then be multiplied by
-  /// the weight matrix to give the coefficients of the interpolated function.
-  /// This returns the pair (weight matrix, array of points)
-  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info() const;
+  /// evaluated at each point given by FiniteElement::points(). These function
+  /// values should then be multiplied by the weight matrix to give the
+  /// coefficients of the interpolated function.
+  Eigen::MatrixXd interpolation_matrix() const;
 
 private:
   // Cell type
@@ -343,13 +343,15 @@ private:
   // Set of points used for point evaluation
   // Experimental - currently used for an implementation of "tabulate_dof_coordinates"
   // Most useful for Lagrange. This may change or go away.
+  // For non-Lagrange elements, these points will be used in combination with
+  // _interpolation_matrix to perform interpolation
   Eigen::ArrayXXd _points;
 
   // The name of the finite element family
   std::string _family_name;
 
   /// The interpolation weights and points
-  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> _interpolation_info;
+  Eigen::MatrixXd _interpolation_matrix;
 };
 
 /// Create an element by name

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -155,7 +155,7 @@ public:
                 const std::vector<std::vector<int>>& entity_dofs,
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
-                const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info={});
+                const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info={});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -308,7 +308,7 @@ public:
   const Eigen::ArrayXXd& points() const;
 
   /// TODO: Document
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> interpolation_info() const;
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info() const;
 
 private:
   // Cell type
@@ -348,10 +348,10 @@ private:
   /// For each dof      std::vector<
   ///                     std::pair<
   ///   List of weights     Eigen::ArrayXd,
-  ///   List of points      Eigen::ArrayX2d
+  ///   List of points      Eigen::ArrayXXd
   ///                     >
   ///                   >
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayX2d>> _interpolation_info;
+  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> _interpolation_info;
 };
 
 /// Create an element by name

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -155,7 +155,7 @@ public:
                 const std::vector<std::vector<int>>& entity_dofs,
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
-                const std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info={});
+                const std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info={});
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -308,7 +308,7 @@ public:
   const Eigen::ArrayXXd& points() const;
 
   /// TODO: Document
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> interpolation_info() const;
+  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> interpolation_info() const;
 
 private:
   // Cell type
@@ -351,7 +351,7 @@ private:
   ///   List of points      Eigen::ArrayXXd
   ///                     >
   ///                   >
-  std::vector<std::pair<Eigen::ArrayXd, Eigen::ArrayXXd>> _interpolation_info;
+  std::pair<Eigen::MatrixXd, Eigen::ArrayXXd> _interpolation_info;
 };
 
 /// Create an element by name

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -318,6 +318,9 @@ private:
   // Cell type
   cell::type _cell_type;
 
+  // The name of the finite element family
+  std::string _family_name;
+
   // Degree
   int _degree;
 
@@ -346,9 +349,6 @@ private:
   // For non-Lagrange elements, these points will be used in combination with
   // _interpolation_matrix to perform interpolation
   Eigen::ArrayXXd _points;
-
-  // The name of the finite element family
-  std::string _family_name;
 
   /// The interpolation weights and points
   Eigen::MatrixXd _interpolation_matrix;

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -106,7 +106,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family_name", &FiniteElement::family_name)
-      .def_property_readonly("interpolation_info", &FiniteElement::interpolation_info);
+      .def_property_readonly("points", &FiniteElement::points)
+      .def_property_readonly("interpolation_matrix", &FiniteElement::interpolation_matrix);
 
   // TODO: remove - not part of public interface
   // Create FiniteElement of different types

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -105,7 +105,8 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .def_property_readonly("entity_dofs", &FiniteElement::entity_dofs)
       .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
-      .def_property_readonly("family_name", &FiniteElement::family_name);
+      .def_property_readonly("family_name", &FiniteElement::family_name)
+      .def_property_readonly("interpolation_info", &FiniteElement::interpolation_info);
 
   // TODO: remove - not part of public interface
   // Create FiniteElement of different types

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -11,6 +11,6 @@ import pytest
 @pytest.mark.parametrize("element_type", ["Lagrange"])
 def test_interpolation(celltype, n, element_type):
     element = libtab.create_element(element_type, celltype, n)
-    assert element.interpolation_info[0].shape[0] == element.dim
-    assert element.interpolation_info[0].shape[1] == element.interpolation_info[1].shape[0]
-    assert element.interpolation_info[1].shape[1] == len(libtab.topology(element.cell_type)) - 1
+    assert element.interpolation_matrix.shape[0] == element.dim
+    assert element.interpolation_matrix.shape[1] == element.points.shape[0]
+    assert element.points.shape[1] == len(libtab.topology(element.cell_type)) - 1

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -12,3 +12,8 @@ import pytest
 def test_interpolation(celltype, n, element_type):
     element = libtab.create_element(element_type, celltype, n)
     assert len(element.interpolation_info) == element.dim
+
+    tdim = len(libtab.topology(element.cell_type)) - 1
+    for weight, points in element.interpolation_info:
+        for p in points:
+            assert len(p) == tdim

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -11,9 +11,6 @@ import pytest
 @pytest.mark.parametrize("element_type", ["Lagrange"])
 def test_interpolation(celltype, n, element_type):
     element = libtab.create_element(element_type, celltype, n)
-    assert len(element.interpolation_info) == element.dim
-
-    tdim = len(libtab.topology(element.cell_type)) - 1
-    for weight, points in element.interpolation_info:
-        for p in points:
-            assert len(p) == tdim
+    assert element.interpolation_info[0].shape[0] == element.dim
+    assert element.interpolation_info[0].shape[1] == element.interpolation_info[1].shape[0]
+    assert element.interpolation_info[1].shape[1] == len(libtab.topology(element.cell_type)) - 1

--- a/test/test_interpolation.py
+++ b/test/test_interpolation.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2020 Matthew Scroggs
+# FEniCS Project
+# SPDX-License-Identifier: MIT
+
+import libtab
+import pytest
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5])
+@pytest.mark.parametrize("celltype", ["interval", "triangle", "tetrahedron"])
+@pytest.mark.parametrize("element_type", ["Lagrange"])
+def test_interpolation(celltype, n, element_type):
+    element = libtab.create_element(element_type, celltype, n)
+    assert len(element.interpolation_info) == element.dim


### PR DESCRIPTION
Added a function that return a matrix of weights and array of points to represent how to interpolate into a finite element (#15).

For example:

- for Lagrange spaces, the points will be the dof locations, and the matrix is the identity.
- for spaces with integral moments, the points will the quadrature points, and the matrix will contain the quadrature weights.

Currently this is only implemented for Lagrange spaces.