### PR TITLE
Hcurl interpolation

### DIFF
--- a/cpp/crouzeix-raviart.cpp
+++ b/cpp/crouzeix-raviart.cpp
@@ -19,6 +19,9 @@ FiniteElement cr::create(cell::type celltype, int degree)
     throw std::runtime_error("Degree must be 1 for Crouzeix-Raviart");
 
   const int tdim = cell::topological_dimension(celltype);
+  if (tdim < 2)
+    throw std::runtime_error("Tdim must be 2 or 3 for Crouzeix-Raviart");
+
   const std::vector<std::vector<std::vector<int>>> topology
       = cell::topology(celltype);
   const std::vector<std::vector<int>> facet_topology = topology[tdim - 1];
@@ -38,7 +41,7 @@ FiniteElement cr::create(cell::type celltype, int degree)
   }
 
   Eigen::MatrixXd dual = polyset::tabulate(celltype, 1, 0, pts)[0];
-  int perm_count = 0;
+  int perm_count = tdim == 2 ? 3 : 14;
   std::vector<Eigen::MatrixXd> base_permutations(
       perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
 

--- a/cpp/libtab.cpp
+++ b/cpp/libtab.cpp
@@ -77,11 +77,12 @@ FiniteElement::FiniteElement(
     const std::vector<int>& value_shape, const Eigen::ArrayXXd& coeffs,
     const std::vector<std::vector<int>>& entity_dofs,
     const std::vector<Eigen::MatrixXd>& base_permutations,
-    const Eigen::ArrayXXd& points, const Eigen::MatrixXd interpolation_matrix)
+    const Eigen::ArrayXXd& points, const Eigen::MatrixXd interpolation_matrix,
+    const std::string mapping_name)
     : _cell_type(cell_type), _family_name(name), _degree(degree),
-      _value_shape(value_shape), _coeffs(coeffs), _entity_dofs(entity_dofs),
-      _base_permutations(base_permutations), _points(points),
-      _interpolation_matrix(interpolation_matrix)
+      _value_shape(value_shape), _mapping_name(mapping_name), _coeffs(coeffs),
+      _entity_dofs(entity_dofs), _base_permutations(base_permutations),
+      _points(points), _interpolation_matrix(interpolation_matrix)
 {
   // Check that entity dofs add up to total number of dofs
   int sum = 0;
@@ -115,6 +116,8 @@ const std::vector<int>& FiniteElement::value_shape() const
 int FiniteElement::dim() const { return _coeffs.rows(); }
 //-----------------------------------------------------------------------------
 std::string FiniteElement::family_name() const { return _family_name; }
+//-----------------------------------------------------------------------------
+std::string FiniteElement::mapping_name() const { return _mapping_name; }
 //-----------------------------------------------------------------------------
 Eigen::MatrixXd
 FiniteElement::interpolation_matrix() const { return _interpolation_matrix; }

--- a/cpp/libtab.h
+++ b/cpp/libtab.h
@@ -155,7 +155,8 @@ public:
                 const std::vector<std::vector<int>>& entity_dofs,
                 const std::vector<Eigen::MatrixXd>& base_permutations,
                 const Eigen::ArrayXXd& points,
-                const Eigen::MatrixXd interpolation_matrix={});
+                const Eigen::MatrixXd interpolation_matrix = {},
+                const std::string mapping_name = "affine");
 
   /// Copy constructor
   FiniteElement(const FiniteElement& element) = default;
@@ -213,6 +214,10 @@ public:
   /// Get the name of the finite element family
   /// @return The family name
   std::string family_name() const;
+
+  /// Get the mapping used for this element
+  /// @return The mapping
+  std::string mapping_name() const;
 
   /// Get the number of dofs on each topological entity: (vertices,
   /// edges, faces, cell) in that order. For example, Lagrange degree 2
@@ -326,6 +331,9 @@ private:
 
   // Value shape
   std::vector<int> _value_shape;
+
+  /// The mapping used to map this element from the reference to a cell
+  std::string _mapping_name;
 
   // Shape function coefficient of expansion sets on cell. If shape
   // function is given by @f$\psi_i = \sum_{k} \phi_{k} \alpha^{i}_{k}@f$,

--- a/cpp/moments.cpp
+++ b/cpp/moments.cpp
@@ -176,6 +176,73 @@ Eigen::MatrixXd moments::make_dot_integral_moments(
   return dual;
 }
 //----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+moments::make_dot_integral_moments_interpolation(
+    const FiniteElement& moment_space, const cell::type celltype,
+    const int value_size, const int poly_deg, const int q_deg)
+{
+  const cell::type sub_celltype = moment_space.cell_type();
+  const int sub_entity_dim = cell::topological_dimension(sub_celltype);
+  const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
+  const int tdim = cell::topological_dimension(celltype);
+
+  auto [Qpts, Qwts] = quadrature::make_quadrature(cell::type::interval, q_deg);
+
+  // If this is always true, value_size input can be removed
+  assert(tdim == value_size);
+
+  // Evaluate moment space at quadrature points
+  Eigen::ArrayXXd moment_space_at_Qpts = moment_space.tabulate(0, Qpts)[0];
+  const int moment_space_size = moment_space_at_Qpts.cols() / sub_entity_dim;
+
+  Eigen::ArrayXXd points(sub_entity_count * Qpts.rows(), tdim);
+  Eigen::MatrixXd matrix(moment_space_at_Qpts.cols() * sub_entity_count,
+                         sub_entity_count * Qpts.rows() * value_size);
+  matrix.setZero();
+
+  int c = 0;
+
+  // Iterate over sub entities
+  for (int i = 0; i < sub_entity_count; ++i)
+  {
+    Eigen::ArrayXXd entity
+        = cell::sub_entity_geometry(celltype, sub_entity_dim, i);
+
+    // Parametrise entity coordinates
+    Eigen::ArrayXXd axes(sub_entity_dim, tdim);
+    for (int j = 0; j < sub_entity_dim; ++j)
+      axes.row(j) = entity.row(j + 1) - entity.row(0);
+
+    // Map quadrature points onto entity
+    Eigen::ArrayXXd Qpts_scaled = entity.row(0).replicate(Qpts.rows(), 1)
+                                  + (Qpts.matrix() * axes.matrix()).array();
+
+    const double integral_jac = integral_jacobian(axes);
+
+    // Compute entity integral moments
+    for (int j = 0; j < moment_space_size; ++j)
+    {
+      for (int k = 0; k < value_size; ++k)
+      {
+        Eigen::VectorXd q = Eigen::VectorXd::Zero(Qwts.rows());
+        for (int d = 0; d < sub_entity_dim; ++d)
+        {
+          Eigen::ArrayXd phi
+              = moment_space_at_Qpts.col(d * moment_space_size + j);
+          Eigen::VectorXd axis = axes.row(d);
+          Eigen::VectorXd qpart
+              = phi * Qwts * (integral_jac * axis(k) / axis.norm());
+          q += qpart;
+        }
+        matrix.block(c, (i * value_size + k) * Qpts.rows(), 1, Qpts.rows()) = q;
+      }
+      ++c;
+    }
+  }
+
+  return std::make_pair(points, matrix);
+}
+//----------------------------------------------------------------------------
 Eigen::MatrixXd moments::make_tangent_integral_moments(
     const FiniteElement& moment_space, const cell::type celltype,
     const int value_size, const int poly_deg, const int q_deg)
@@ -237,6 +304,70 @@ Eigen::MatrixXd moments::make_tangent_integral_moments(
   }
 
   return dual;
+}
+//----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+moments::make_tangent_integral_moments_interpolation(
+    const FiniteElement& moment_space, const cell::type celltype,
+    const int value_size, const int poly_deg, const int q_deg)
+{
+  const cell::type sub_celltype = moment_space.cell_type();
+  const int sub_entity_dim = cell::topological_dimension(sub_celltype);
+  const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
+  const int tdim = cell::topological_dimension(celltype);
+
+  if (sub_entity_dim != 1)
+    throw std::runtime_error("Tangent is only well-defined on an edge.");
+
+  auto [Qpts, Qwts] = quadrature::make_quadrature(cell::type::interval, q_deg);
+
+  // If this is always true, value_size input can be removed
+  assert(tdim == value_size);
+
+  // Evaluate moment space at quadrature points
+  Eigen::ArrayXXd moment_space_at_Qpts = moment_space.tabulate(0, Qpts)[0];
+
+  Eigen::ArrayXXd points(sub_entity_count * Qpts.rows(), tdim);
+  Eigen::MatrixXd matrix(moment_space_at_Qpts.cols() * sub_entity_count,
+                         sub_entity_count * Qpts.rows() * value_size);
+  matrix.setZero();
+
+  int c = 0;
+
+  // Iterate over sub entities
+  for (int i = 0; i < sub_entity_count; ++i)
+  {
+    Eigen::Array2Xd edge = cell::sub_entity_geometry(celltype, 1, i);
+    Eigen::VectorXd tangent = edge.row(1) - edge.row(0);
+    // No need to normalise the tangent, as the size of this is equal to the
+    // integral jacobian
+
+    // Map quadrature points onto triangle edge
+    Eigen::ArrayXXd Qpts_scaled(Qpts.rows(), tdim);
+    for (int j = 0; j < Qpts.rows(); ++j)
+    {
+      points.row(i * Qpts.rows() + j)
+          = edge.row(0) + Qpts(j, 0) * (edge.row(1) - edge.row(0));
+    }
+
+    // Compute edge tangent integral moments
+    for (int j = 0; j < moment_space_at_Qpts.cols(); ++j)
+    {
+      Eigen::ArrayXd phi = moment_space_at_Qpts.col(j);
+      for (int k = 0; k < value_size; ++k)
+      {
+        Eigen::ArrayXd data = phi * Qwts * tangent[k];
+        for (int l = 0; l < data.rows(); ++l)
+          // matrix(c, i * value_size * Qpts.rows() + l * value_size + k) =
+          // data(l);
+          matrix(c, k * sub_entity_count * Qpts.rows() + i * Qpts.rows() + l)
+              = data(l);
+      }
+      ++c;
+    }
+  }
+
+  return std::make_pair(points, matrix);
 }
 //----------------------------------------------------------------------------
 Eigen::MatrixXd moments::make_normal_integral_moments(

--- a/cpp/moments.cpp
+++ b/cpp/moments.cpp
@@ -124,7 +124,7 @@ moments::make_integral_moments_interpolation(const FiniteElement& moment_space,
 
   Eigen::ArrayXXd points(sub_entity_count * Qpts.rows(), tdim);
   Eigen::MatrixXd matrix(moment_space_at_Qpts.cols() * sub_entity_count
-                             * value_size,
+                             * sub_entity_dim,
                          sub_entity_count * Qpts.rows() * value_size);
   matrix.setZero();
 
@@ -266,7 +266,7 @@ moments::make_dot_integral_moments_interpolation(
   const int moment_space_size = moment_space_at_Qpts.cols() / sub_entity_dim;
 
   Eigen::ArrayXXd points(sub_entity_count * Qpts.rows(), tdim);
-  Eigen::MatrixXd matrix(moment_space_at_Qpts.cols() * sub_entity_count,
+  Eigen::MatrixXd matrix(moment_space_size * sub_entity_count,
                          sub_entity_count * Qpts.rows() * value_size);
   matrix.setZero();
 
@@ -526,5 +526,95 @@ Eigen::MatrixXd moments::make_normal_integral_moments(
   }
 
   return dual;
+}
+//----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+moments::make_normal_integral_moments_interpolation(
+    const FiniteElement& moment_space, const cell::type celltype,
+    const int value_size, const int poly_deg, const int q_deg)
+{
+  const cell::type sub_celltype = moment_space.cell_type();
+  const int sub_entity_dim = cell::topological_dimension(sub_celltype);
+  const int sub_entity_count = cell::sub_entity_count(celltype, sub_entity_dim);
+  const int tdim = cell::topological_dimension(celltype);
+
+  if (sub_entity_dim != tdim - 1)
+    throw std::runtime_error("Normal is only well-defined on a facet.");
+
+  auto [Qpts, Qwts] = quadrature::make_quadrature(sub_celltype, q_deg);
+
+  // If this is always true, value_size input can be removed
+  assert(tdim == value_size);
+
+  // Evaluate moment space at quadrature points
+  Eigen::ArrayXXd moment_space_at_Qpts = moment_space.tabulate(0, Qpts)[0];
+
+  Eigen::ArrayXXd points(sub_entity_count * Qpts.rows(), tdim);
+  Eigen::MatrixXd matrix(moment_space_at_Qpts.cols() * sub_entity_count,
+                         sub_entity_count * Qpts.rows() * value_size);
+  matrix.setZero();
+
+  int c = 0;
+
+  // Iterate over sub entities
+  Eigen::VectorXd normal(tdim);
+  Eigen::ArrayXXd Qpts_scaled(Qpts.rows(), tdim);
+  for (int i = 0; i < sub_entity_count; ++i)
+  {
+    Eigen::ArrayXXd facet = cell::sub_entity_geometry(celltype, tdim - 1, i);
+    if (tdim == 2)
+    {
+      Eigen::Vector2d tangent = facet.row(1) - facet.row(0);
+      normal << -tangent(1), tangent(0);
+      // No need to normalise the normal, as the size of this is equal to the
+      // integral jacobian
+
+      // Map quadrature points onto facet
+      for (int j = 0; j < Qpts.rows(); ++j)
+      {
+        points.row(i * Qpts.rows() + j)
+            = facet.row(0) + Qpts(j, 0) * (facet.row(1) - facet.row(0));
+      }
+    }
+    else if (tdim == 3)
+    {
+      Eigen::Vector3d t0 = facet.row(1) - facet.row(0);
+      Eigen::Vector3d t1 = facet.row(2) - facet.row(0);
+      normal = t0.cross(t1);
+
+      // No need to normalise the normal, as the size of this is equal to the
+      // integral jacobian
+
+      // Map quadrature points onto facet
+      for (int j = 0; j < Qpts.rows(); ++j)
+      {
+        points.row(i * Qpts.rows() + j)
+            = facet.row(0) + Qpts(j, 0) * (facet.row(1) - facet.row(0))
+              + Qpts(j, 1) * (facet.row(2) - facet.row(0));
+      }
+    }
+    else
+      throw std::runtime_error("Normal on this cell cannot be computed.");
+
+    // Tabulate polynomial set at facet quadrature points
+    Eigen::MatrixXd poly_set_at_Qpts
+        = polyset::tabulate(celltype, poly_deg, 0, Qpts_scaled)[0].transpose();
+
+    // Compute facet normal integral moments
+    for (int j = 0; j < moment_space_at_Qpts.cols(); ++j)
+    {
+      Eigen::ArrayXd phi = moment_space_at_Qpts.col(j);
+      for (int k = 0; k < value_size; ++k)
+      {
+        Eigen::VectorXd q = phi * Qwts * normal[k];
+        for (int l = 0; l < q.rows(); ++l)
+          matrix(c, k * sub_entity_count * Qpts.rows() + i * Qpts.rows() + l)
+              = q(l);
+      }
+      ++c;
+    }
+  }
+
+  return std::make_pair(points, matrix);
 }
 //----------------------------------------------------------------------------

--- a/cpp/moments.h
+++ b/cpp/moments.h
@@ -35,6 +35,9 @@ Eigen::MatrixXd make_integral_moments(const FiniteElement& moment_space,
                                       const cell::type celltype,
                                       const int value_size, const int poly_deg,
                                       const int q_deg);
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd> make_integral_moments_interpolation(
+    const FiniteElement& moment_space, const cell::type celltype,
+    const int value_size, const int poly_deg, const int q_deg);
 
 /// Make dot product integral moments
 ///

--- a/cpp/moments.h
+++ b/cpp/moments.h
@@ -54,6 +54,11 @@ Eigen::MatrixXd make_dot_integral_moments(const FiniteElement& moment_space,
                                           const cell::type celltype,
                                           const int value_size,
                                           const int poly_deg, const int q_deg);
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+make_dot_integral_moments_interpolation(const FiniteElement& moment_space,
+                                        const cell::type celltype,
+                                        const int value_size,
+                                        const int poly_deg, const int q_deg);
 
 /// Make tangential integral moments
 ///
@@ -72,6 +77,14 @@ Eigen::MatrixXd make_tangent_integral_moments(const FiniteElement& moment_space,
                                               const int value_size,
                                               const int poly_deg,
                                               const int q_deg);
+
+/// Make interpolation points and weights for tangent integral moments
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+make_tangent_integral_moments_interpolation(const FiniteElement& moment_space,
+                                            const cell::type celltype,
+                                            const int value_size,
+                                            const int poly_deg,
+                                            const int q_deg);
 
 /// Make normal integral moments
 ///

--- a/cpp/moments.h
+++ b/cpp/moments.h
@@ -35,6 +35,15 @@ Eigen::MatrixXd make_integral_moments(const FiniteElement& moment_space,
                                       const cell::type celltype,
                                       const int value_size, const int poly_deg,
                                       const int q_deg);
+
+/// Make interpolation points and weights for simple integral moments
+///
+/// @param moment_space The space to compute the integral moments against
+/// @param celltype The cell type of the cell on which the space is being
+/// defined
+/// @param value_size The value size of the space being defined
+/// @param poly_deg The polynomial degree of the poly set that defines the space
+/// @param q_deg The quadrature degree used for the integrals
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd> make_integral_moments_interpolation(
     const FiniteElement& moment_space, const cell::type celltype,
     const int value_size, const int poly_deg, const int q_deg);
@@ -57,6 +66,15 @@ Eigen::MatrixXd make_dot_integral_moments(const FiniteElement& moment_space,
                                           const cell::type celltype,
                                           const int value_size,
                                           const int poly_deg, const int q_deg);
+
+/// Make interpolation points and weights for dot product integral moments
+///
+/// @param moment_space The space to compute the integral moments against
+/// @param celltype The cell type of the cell on which the space is being
+/// defined
+/// @param value_size The value size of the space being defined
+/// @param poly_deg The polynomial degree of the poly set that defines the space
+/// @param q_deg The quadrature degree used for the integrals
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
 make_dot_integral_moments_interpolation(const FiniteElement& moment_space,
                                         const cell::type celltype,
@@ -82,6 +100,17 @@ Eigen::MatrixXd make_tangent_integral_moments(const FiniteElement& moment_space,
                                               const int q_deg);
 
 /// Make interpolation points and weights for tangent integral moments
+///
+/// These can only be used when the moment space is defined on edges of
+/// the cell
+///
+/// @param moment_space The space to compute the integral moments against
+/// @param celltype The cell type of the cell on which the space is
+/// being defined
+/// @param value_size The value size of the space being defined
+/// @param poly_deg The polynomial degree of the poly set that defines
+/// the space
+/// @param q_deg The quadrature degree used for the integrals
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
 make_tangent_integral_moments_interpolation(const FiniteElement& moment_space,
                                             const cell::type celltype,
@@ -101,12 +130,29 @@ make_tangent_integral_moments_interpolation(const FiniteElement& moment_space,
 /// @param poly_deg The polynomial degree of the poly set that defines
 /// the space
 /// @param q_deg The quadrature degree used for the integrals
-// TODO: Implement this one in integral-moments.cpp
 Eigen::MatrixXd make_normal_integral_moments(const FiniteElement& moment_space,
                                              const cell::type celltype,
                                              const int value_size,
                                              const int poly_deg,
                                              const int q_deg);
+
+/// Make interpolation points and weights for normal integral moments
+///
+/// These can only be used when the moment space is defined on facets of
+/// the cell
+///
+/// @param moment_space The space to compute the integral moments against
+/// @param celltype The cell type of the cell on which the space is
+/// being defined
+/// @param value_size The value size of the space being defined
+/// @param poly_deg The polynomial degree of the poly set that defines
+/// the space
+/// @param q_deg The quadrature degree used for the integrals
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+make_normal_integral_moments_interpolation(const FiniteElement& moment_space,
+                                           const cell::type celltype,
+                                           const int value_size,
+                                           const int poly_deg, const int q_deg);
 
 }; // namespace moments
 } // namespace libtab

--- a/cpp/nedelec.cpp
+++ b/cpp/nedelec.cpp
@@ -103,14 +103,13 @@ create_nedelec_2d_interpolation(int degree)
           cell::type::triangle, 2, degree, quad_deg);
 
   if (degree == 1)
-    return std::make_pair(points_1d, matrix_1d);
+    return {points_1d, matrix_1d};
 
   Eigen::ArrayXXd points_2d;
   Eigen::MatrixXd matrix_2d;
-  std::tie(points_2d, matrix_2d)
-      = moments::make_dot_integral_moments_interpolation(
-          create_rt(cell::type::triangle, degree - 2), cell::type::triangle, 2,
-          degree, quad_deg);
+  std::tie(points_2d, matrix_2d) = moments::make_integral_moments_interpolation(
+      create_dlagrange(cell::type::triangle, degree - 2), cell::type::triangle,
+      2, degree, quad_deg);
 
   Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows(), 2);
   Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows(),
@@ -127,7 +126,7 @@ create_nedelec_2d_interpolation(int degree)
                matrix_2d.cols())
       = matrix_2d;
 
-  return std::make_pair(points, matrix);
+  return {points, matrix};
 }
 //-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec_2d_base_perms(int degree)
@@ -297,14 +296,13 @@ create_nedelec_3d_interpolation(int degree)
           cell::type::tetrahedron, 3, degree, quad_deg);
 
   if (degree == 1)
-    return std::make_pair(points_1d, matrix_1d);
+    return {points_1d, matrix_1d};
 
   Eigen::ArrayXXd points_2d;
   Eigen::MatrixXd matrix_2d;
-  std::tie(points_2d, matrix_2d)
-      = moments::make_dot_integral_moments_interpolation(
-          create_rt(cell::type::triangle, degree - 2), cell::type::tetrahedron,
-          3, degree, quad_deg);
+  std::tie(points_2d, matrix_2d) = moments::make_integral_moments_interpolation(
+      create_dlagrange(cell::type::triangle, degree - 2),
+      cell::type::tetrahedron, 3, degree, quad_deg);
 
   if (degree == 2)
   {
@@ -319,15 +317,14 @@ create_nedelec_3d_interpolation(int degree)
                  matrix_2d.cols())
         = matrix_2d;
 
-    return std::make_pair(points, matrix);
+    return {points, matrix};
   }
 
   Eigen::ArrayXXd points_3d;
   Eigen::MatrixXd matrix_3d;
-  std::tie(points_3d, matrix_3d)
-      = moments::make_dot_integral_moments_interpolation(
-          create_dlagrange(cell::type::tetrahedron, degree - 3),
-          cell::type::tetrahedron, 3, degree, quad_deg);
+  std::tie(points_3d, matrix_3d) = moments::make_integral_moments_interpolation(
+      create_dlagrange(cell::type::tetrahedron, degree - 3),
+      cell::type::tetrahedron, 3, degree, quad_deg);
 
   Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows() + points_3d.rows(),
                          3);
@@ -348,7 +345,7 @@ create_nedelec_3d_interpolation(int degree)
                matrix_3d.cols())
       = matrix_3d;
 
-  return std::make_pair(points, matrix);
+  return {points, matrix};
 }
 //-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec_3d_base_perms(int degree)
@@ -470,7 +467,7 @@ create_nedelec2_2d_interpolation(int degree)
           2, degree, quad_deg);
 
   if (degree == 1)
-    return std::make_pair(points_1d, matrix_1d);
+    return {points_1d, matrix_1d};
 
   Eigen::ArrayXXd points_2d;
   Eigen::MatrixXd matrix_2d;
@@ -494,7 +491,7 @@ create_nedelec2_2d_interpolation(int degree)
                matrix_2d.cols())
       = matrix_2d;
 
-  return std::make_pair(points, matrix);
+  return {points, matrix};
 }
 //-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec2_2d_base_permutations(int degree)
@@ -577,7 +574,7 @@ create_nedelec2_3d_interpolation(int degree)
   // TODO
   Eigen::ArrayXXd points(0, 0);
   Eigen::MatrixXd matrix(0, 0);
-  return std::make_pair(points, matrix);
+  return {points, matrix};
 }
 //-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec2_3d_base_permutations(int degree)
@@ -632,7 +629,7 @@ FiniteElement libtab::create_nedelec(cell::type celltype, int degree,
 
   const Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       perms, points, interp_matrix);
+                       perms, points, interp_matrix, "covariant piola");
 }
 //-----------------------------------------------------------------------------
 FiniteElement libtab::create_nedelec2(cell::type celltype, int degree,
@@ -678,6 +675,7 @@ FiniteElement libtab::create_nedelec2(cell::type celltype, int degree,
     entity_dofs[3] = {(degree - 2) * (degree - 1) * (degree + 1) / 2};
 
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, points, interp_matrix);
+                       base_permutations, points, interp_matrix,
+                       "covariant piola");
 }
 //-----------------------------------------------------------------------------

--- a/cpp/nedelec.cpp
+++ b/cpp/nedelec.cpp
@@ -89,6 +89,47 @@ Eigen::MatrixXd create_nedelec_2d_dual(int degree)
   return dual;
 }
 //-----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+create_nedelec_2d_interpolation(int degree)
+{
+  // Number of dofs and interpolation points
+  int quad_deg = 5 * degree;
+
+  Eigen::ArrayXXd points_1d;
+  Eigen::MatrixXd matrix_1d;
+  std::tie(points_1d, matrix_1d)
+      = moments::make_tangent_integral_moments_interpolation(
+          create_dlagrange(cell::type::interval, degree - 1),
+          cell::type::triangle, 2, degree, quad_deg);
+
+  if (degree == 1)
+    return std::make_pair(points_1d, matrix_1d);
+
+  Eigen::ArrayXXd points_2d;
+  Eigen::MatrixXd matrix_2d;
+  std::tie(points_2d, matrix_2d)
+      = moments::make_dot_integral_moments_interpolation(
+          create_rt(cell::type::triangle, degree - 2), cell::type::triangle, 2,
+          degree, quad_deg);
+
+  Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows(), 2);
+  Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows(),
+                         matrix_1d.cols() + matrix_2d.cols());
+  matrix.setZero();
+  assert(points_1d.rows() + points_2d.rows() * 2
+         == matrix_1d.cols() + matrix_2d.cols());
+  assert(matrix_1d.rows() + matrix_2d.rows() == (degree + 1) * (degree + 2));
+
+  points.block(0, 0, points_1d.rows(), 2) = points_1d;
+  points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
+  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
+  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
+               matrix_2d.cols())
+      = matrix_2d;
+
+  return std::make_pair(points, matrix);
+}
+//-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec_2d_base_perms(int degree)
 {
   const int ndofs = degree * (degree + 2);
@@ -242,6 +283,74 @@ Eigen::MatrixXd create_nedelec_3d_dual(int degree)
   return dual;
 }
 //-----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+create_nedelec_3d_interpolation(int degree)
+{
+  // Number of dofs and interpolation points
+  int quad_deg = 5 * degree;
+
+  Eigen::ArrayXXd points_1d;
+  Eigen::MatrixXd matrix_1d;
+  std::tie(points_1d, matrix_1d)
+      = moments::make_tangent_integral_moments_interpolation(
+          create_dlagrange(cell::type::interval, degree - 1),
+          cell::type::tetrahedron, 3, degree, quad_deg);
+
+  if (degree == 1)
+    return std::make_pair(points_1d, matrix_1d);
+
+  Eigen::ArrayXXd points_2d;
+  Eigen::MatrixXd matrix_2d;
+  std::tie(points_2d, matrix_2d)
+      = moments::make_dot_integral_moments_interpolation(
+          create_rt(cell::type::triangle, degree - 2), cell::type::tetrahedron,
+          3, degree, quad_deg);
+
+  if (degree == 2)
+  {
+    Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows(), 3);
+    Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows(),
+                           matrix_1d.cols() + matrix_2d.cols());
+    matrix.setZero();
+    points.block(0, 0, points_1d.rows(), 2) = points_1d;
+    points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
+    matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
+    matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
+                 matrix_2d.cols())
+        = matrix_2d;
+
+    return std::make_pair(points, matrix);
+  }
+
+  Eigen::ArrayXXd points_3d;
+  Eigen::MatrixXd matrix_3d;
+  std::tie(points_3d, matrix_3d)
+      = moments::make_dot_integral_moments_interpolation(
+          create_dlagrange(cell::type::tetrahedron, degree - 3),
+          cell::type::tetrahedron, 3, degree, quad_deg);
+
+  Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows() + points_3d.rows(),
+                         3);
+  Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows() + matrix_3d.rows(),
+                         matrix_1d.cols() + matrix_2d.cols()
+                             + matrix_3d.cols());
+  matrix.setZero();
+  points.block(0, 0, points_1d.rows(), 2) = points_1d;
+  points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
+  points.block(points_1d.rows() + points_2d.rows(), 0, points_3d.rows(), 2)
+      = points_3d;
+  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
+  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
+               matrix_2d.cols())
+      = matrix_2d;
+  matrix.block(matrix_1d.rows() + matrix_2d.rows(),
+               matrix_1d.cols() + matrix_2d.cols(), matrix_3d.rows(),
+               matrix_3d.cols())
+      = matrix_3d;
+
+  return std::make_pair(points, matrix);
+}
+//-----------------------------------------------------------------------------
 std::vector<Eigen::MatrixXd> create_nedelec_3d_base_perms(int degree)
 {
   const int ndofs = 6 * degree + 4 * degree * (degree - 1)
@@ -347,6 +456,78 @@ Eigen::MatrixXd create_nedelec2_2d_dual(int degree)
   return dual;
 }
 //-----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+create_nedelec2_2d_interpolation(int degree)
+{
+  // Number of dofs and interpolation points
+  int quad_deg = 5 * degree;
+
+  Eigen::ArrayXXd points_1d;
+  Eigen::MatrixXd matrix_1d;
+  std::tie(points_1d, matrix_1d)
+      = moments::make_tangent_integral_moments_interpolation(
+          create_dlagrange(cell::type::interval, degree), cell::type::triangle,
+          2, degree, quad_deg);
+
+  if (degree == 1)
+    return std::make_pair(points_1d, matrix_1d);
+
+  Eigen::ArrayXXd points_2d;
+  Eigen::MatrixXd matrix_2d;
+  std::tie(points_2d, matrix_2d)
+      = moments::make_dot_integral_moments_interpolation(
+          create_rt(cell::type::triangle, degree - 1), cell::type::triangle, 2,
+          degree, quad_deg);
+
+  Eigen::ArrayXXd points(points_1d.rows() + points_2d.rows(), 2);
+  Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows(),
+                         matrix_1d.cols() + matrix_2d.cols());
+  matrix.setZero();
+  assert(points_1d.rows() + points_2d.rows() * 2
+         == matrix_1d.cols() + matrix_2d.cols());
+  assert(matrix_1d.rows() + matrix_2d.rows() == (degree + 1) * (degree + 2));
+
+  points.block(0, 0, points_1d.rows(), 2) = points_1d;
+  points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
+  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
+  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
+               matrix_2d.cols())
+      = matrix_2d;
+
+  return std::make_pair(points, matrix);
+}
+//-----------------------------------------------------------------------------
+std::vector<Eigen::MatrixXd> create_nedelec2_2d_base_permutations(int degree)
+{
+  const int ndofs = (degree + 1) * (degree + 2);
+  std::vector<Eigen::MatrixXd> base_permutations(
+      3, Eigen::MatrixXd::Identity(ndofs, ndofs));
+
+  Eigen::ArrayXi edge_ref = dofperms::interval_reflection(degree + 1);
+  for (int edge = 0; edge < 3; ++edge)
+  {
+    const int start = edge_ref.size() * edge;
+    for (int i = 0; i < edge_ref.size(); ++i)
+    {
+      base_permutations[edge](start + i, start + i) = 0;
+      base_permutations[edge](start + i, start + edge_ref[i]) = 1;
+    }
+  }
+
+  Eigen::ArrayXXd edge_dir
+      = dofperms::interval_reflection_tangent_directions(degree + 1);
+  for (int edge = 0; edge < 3; ++edge)
+  {
+    Eigen::MatrixXd directions = Eigen::MatrixXd::Identity(ndofs, ndofs);
+    directions.block(edge_dir.rows() * edge, edge_dir.cols() * edge,
+                     edge_dir.rows(), edge_dir.cols())
+        = edge_dir;
+    base_permutations[edge] *= directions;
+  }
+
+  return base_permutations;
+}
+//-----------------------------------------------------------------------------
 Eigen::MatrixXd create_nedelec2_3d_dual(int degree)
 {
   const int tdim = 3;
@@ -389,6 +570,24 @@ Eigen::MatrixXd create_nedelec2_3d_dual(int degree)
 
   return dual;
 }
+//-----------------------------------------------------------------------------
+std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
+create_nedelec2_3d_interpolation(int degree)
+{
+  // TODO
+  Eigen::ArrayXXd points(0, 0);
+  Eigen::MatrixXd matrix(0, 0);
+  return std::make_pair(points, matrix);
+}
+//-----------------------------------------------------------------------------
+std::vector<Eigen::MatrixXd> create_nedelec2_3d_base_permutations(int degree)
+{
+  // TODO
+  const int ndofs = (degree + 1) * (degree + 2) * (degree + 3) / 2;
+  std::vector<Eigen::MatrixXd> base_permutations(
+      14, Eigen::MatrixXd::Identity(ndofs, ndofs));
+  return base_permutations;
+}
 
 } // namespace
 
@@ -398,17 +597,21 @@ FiniteElement libtab::create_nedelec(cell::type celltype, int degree,
 {
   Eigen::MatrixXd wcoeffs;
   Eigen::MatrixXd dual;
+  Eigen::ArrayXXd points;
+  Eigen::MatrixXd interp_matrix;
   std::vector<Eigen::MatrixXd> perms;
   std::vector<Eigen::MatrixXd> directions;
   if (celltype == cell::type::triangle)
   {
     wcoeffs = create_nedelec_2d_space(degree);
+    std::tie(points, interp_matrix) = create_nedelec_2d_interpolation(degree);
     dual = create_nedelec_2d_dual(degree);
     perms = create_nedelec_2d_base_perms(degree);
   }
   else if (celltype == cell::type::tetrahedron)
   {
     wcoeffs = create_nedelec_3d_space(degree);
+    std::tie(points, interp_matrix) = create_nedelec_3d_interpolation(degree);
     dual = create_nedelec_3d_dual(degree);
     perms = create_nedelec_3d_base_perms(degree);
   }
@@ -429,7 +632,7 @@ FiniteElement libtab::create_nedelec(cell::type celltype, int degree,
 
   const Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       perms,{});
+                       perms, points, interp_matrix);
 }
 //-----------------------------------------------------------------------------
 FiniteElement libtab::create_nedelec2(cell::type celltype, int degree,
@@ -440,23 +643,28 @@ FiniteElement libtab::create_nedelec2(cell::type celltype, int degree,
   Eigen::MatrixXd wcoeffs
       = Eigen::MatrixXd::Identity(tdim * psize, tdim * psize);
 
-  Eigen::MatrixXd dual;
-  if (celltype == cell::type::triangle)
-    dual = create_nedelec2_2d_dual(degree);
-  else if (celltype == cell::type::tetrahedron)
-    dual = create_nedelec2_3d_dual(degree);
-  else
-    throw std::runtime_error("Invalid celltype in Nedelec");
-
-  // TODO: Implement base permutations
   const std::vector<std::vector<std::vector<int>>> topology
       = cell::topology(celltype);
-  const int ndofs = dual.rows();
-  int perm_count = 0;
-  for (int i = 1; i < tdim; ++i)
-    perm_count += topology[i].size() * i;
-  std::vector<Eigen::MatrixXd> base_permutations(
-      perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
+
+  Eigen::MatrixXd dual;
+  Eigen::ArrayXXd points;
+  Eigen::MatrixXd interp_matrix;
+  std::vector<Eigen::MatrixXd> base_permutations;
+
+  if (celltype == cell::type::triangle)
+  {
+    dual = create_nedelec2_2d_dual(degree);
+    std::tie(points, interp_matrix) = create_nedelec2_2d_interpolation(degree);
+    base_permutations = create_nedelec2_2d_base_permutations(degree);
+  }
+  else if (celltype == cell::type::tetrahedron)
+  {
+    dual = create_nedelec2_3d_dual(degree);
+    std::tie(points, interp_matrix) = create_nedelec2_3d_interpolation(degree);
+    base_permutations = create_nedelec2_3d_base_permutations(degree);
+  }
+  else
+    throw std::runtime_error("Invalid celltype in Nedelec");
 
   const Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
 
@@ -470,6 +678,6 @@ FiniteElement libtab::create_nedelec2(cell::type celltype, int degree,
     entity_dofs[3] = {(degree - 2) * (degree - 1) * (degree + 1) / 2};
 
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {});
+                       base_permutations, points, interp_matrix);
 }
 //-----------------------------------------------------------------------------

--- a/cpp/nedelec.cpp
+++ b/cpp/nedelec.cpp
@@ -92,6 +92,10 @@ Eigen::MatrixXd create_nedelec_2d_dual(int degree)
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
 create_nedelec_2d_interpolation(int degree)
 {
+  // TODO: fix interpolation for higher order elements
+  if (degree > 2)
+    return {{}, {}};
+
   // Number of dofs and interpolation points
   int quad_deg = 5 * degree;
 
@@ -121,10 +125,18 @@ create_nedelec_2d_interpolation(int degree)
 
   points.block(0, 0, points_1d.rows(), 2) = points_1d;
   points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
-  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
-  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
-               matrix_2d.cols())
-      = matrix_2d;
+
+  for (int i = 0; i < 2; ++i)
+  {
+    const int r1d = matrix_1d.rows();
+    const int r2d = matrix_2d.rows();
+    const int c1d = matrix_1d.cols() / 2;
+    const int c2d = matrix_2d.cols() / 2;
+    matrix.block(0, i * (c1d + c2d), r1d, c1d)
+        = matrix_1d.block(0, i * c1d, r1d, c1d);
+    matrix.block(r1d, i * (c1d + c2d) + c1d, r2d, c2d)
+        = matrix_2d.block(0, i * c2d, r2d, c2d);
+  }
 
   return {points, matrix};
 }
@@ -285,6 +297,10 @@ Eigen::MatrixXd create_nedelec_3d_dual(int degree)
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
 create_nedelec_3d_interpolation(int degree)
 {
+  // TODO: fix interpolation for higher order elements
+  if (degree > 1)
+    return {{}, {}};
+
   // Number of dofs and interpolation points
   int quad_deg = 5 * degree;
 
@@ -310,12 +326,21 @@ create_nedelec_3d_interpolation(int degree)
     Eigen::MatrixXd matrix(matrix_1d.rows() + matrix_2d.rows(),
                            matrix_1d.cols() + matrix_2d.cols());
     matrix.setZero();
+
     points.block(0, 0, points_1d.rows(), 2) = points_1d;
     points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
-    matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
-    matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
-                 matrix_2d.cols())
-        = matrix_2d;
+
+    for (int i = 0; i < 3; ++i)
+    {
+      const int r1d = matrix_1d.rows();
+      const int r2d = matrix_2d.rows();
+      const int c1d = matrix_1d.cols() / 3;
+      const int c2d = matrix_2d.cols() / 3;
+      matrix.block(0, i * (c1d + c2d), r1d, c1d)
+          = matrix_1d.block(0, i * c1d, r1d, c1d);
+      matrix.block(r1d, i * (c1d + c2d) + c1d, r2d, c2d)
+          = matrix_2d.block(0, i * c2d, r2d, c2d);
+    }
 
     return {points, matrix};
   }
@@ -336,14 +361,22 @@ create_nedelec_3d_interpolation(int degree)
   points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
   points.block(points_1d.rows() + points_2d.rows(), 0, points_3d.rows(), 2)
       = points_3d;
-  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
-  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
-               matrix_2d.cols())
-      = matrix_2d;
-  matrix.block(matrix_1d.rows() + matrix_2d.rows(),
-               matrix_1d.cols() + matrix_2d.cols(), matrix_3d.rows(),
-               matrix_3d.cols())
-      = matrix_3d;
+
+  for (int i = 0; i < 3; ++i)
+  {
+    const int r1d = matrix_1d.rows();
+    const int r2d = matrix_2d.rows();
+    const int r3d = matrix_3d.rows();
+    const int c1d = matrix_1d.cols() / 3;
+    const int c2d = matrix_2d.cols() / 3;
+    const int c3d = matrix_3d.cols() / 3;
+    matrix.block(0, i * (c1d + c2d + c3d), r1d, c1d)
+        = matrix_1d.block(0, i * c1d, r1d, c1d);
+    matrix.block(r1d, i * (c1d + c2d + c3d) + c1d, r2d, c2d)
+        = matrix_2d.block(0, i * c2d, r2d, c2d);
+    matrix.block(r1d + r2d, i * (c1d + c2d + c3d) + c1d + c2d, r2d, c2d)
+        = matrix_3d.block(0, i * c3d, r3d, c3d);
+  }
 
   return {points, matrix};
 }
@@ -456,6 +489,10 @@ Eigen::MatrixXd create_nedelec2_2d_dual(int degree)
 std::pair<Eigen::ArrayXXd, Eigen::MatrixXd>
 create_nedelec2_2d_interpolation(int degree)
 {
+  // TODO: fix interpolation for higher order elements
+  if (degree > 1)
+    return {{}, {}};
+
   // Number of dofs and interpolation points
   int quad_deg = 5 * degree;
 
@@ -486,10 +523,18 @@ create_nedelec2_2d_interpolation(int degree)
 
   points.block(0, 0, points_1d.rows(), 2) = points_1d;
   points.block(points_1d.rows(), 0, points_2d.rows(), 2) = points_2d;
-  matrix.block(0, 0, matrix_1d.rows(), matrix_1d.cols()) = matrix_1d;
-  matrix.block(matrix_1d.rows(), matrix_1d.cols(), matrix_2d.rows(),
-               matrix_2d.cols())
-      = matrix_2d;
+
+  for (int i = 0; i < 2; ++i)
+  {
+    const int r1d = matrix_1d.rows();
+    const int r2d = matrix_2d.rows();
+    const int c1d = matrix_1d.cols() / 2;
+    const int c2d = matrix_2d.cols() / 2;
+    matrix.block(0, i * (c1d + c2d), r1d, c1d)
+        = matrix_1d.block(0, i * c1d, r1d, c1d);
+    matrix.block(r1d, i * (c1d + c2d) + c1d, r2d, c2d)
+        = matrix_2d.block(0, i * c2d, r2d, c2d);
+  }
 
   return {points, matrix};
 }

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -102,15 +102,26 @@ FiniteElement libtab::create_rt(cell::type celltype, int degree,
       perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
   if (tdim == 2)
   {
-    Eigen::ArrayXi edge_ref = dofperms::interval_reflection(degree - 1);
+    Eigen::ArrayXi edge_ref = dofperms::interval_reflection(degree);
     for (int edge = 0; edge < facet_count; ++edge)
     {
       const int start = edge_ref.size() * edge;
       for (int i = 0; i < edge_ref.size(); ++i)
       {
         base_permutations[edge](start + i, start + i) = 0;
-        base_permutations[edge](start + i, start + edge_ref[i]) = -1;
+        base_permutations[edge](start + i, start + edge_ref[i]) = 1;
       }
+    }
+
+    Eigen::ArrayXXd edge_dir
+      = dofperms::interval_reflection_tangent_directions(degree);
+    for (int edge = 0; edge < 3; ++edge)
+    {
+      Eigen::MatrixXd directions = Eigen::MatrixXd::Identity(ndofs, ndofs);
+      directions.block(edge_dir.rows() * edge, edge_dir.cols() * edge,
+                       edge_dir.rows(), edge_dir.cols())
+          = edge_dir;
+      base_permutations[edge] *= directions;
     }
   }
   else if (tdim == 3)

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -140,6 +140,6 @@ FiniteElement libtab::create_rt(cell::type celltype, int degree,
 
   Eigen::MatrixXd coeffs = compute_expansion_coefficients(wcoeffs, dual);
   return FiniteElement(name, celltype, degree, {tdim}, coeffs, entity_dofs,
-                       base_permutations, {});
+                       base_permutations, {}, {}, "contravariant piola");
 }
 //-----------------------------------------------------------------------------

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -134,10 +134,10 @@ FiniteElement libtab::create_rt(cell::type celltype, int degree,
       const int start = face_ref.size() * face;
       for (int i = 0; i < face_rot.size(); ++i)
       {
-        base_permutations[2 * face](start + i, start + i) = 0;
-        base_permutations[2 * face](start + i, start + face_rot[i]) = 1;
-        base_permutations[2 * face + 1](start + i, start + i) = 0;
-        base_permutations[2 * face + 1](start + i, start + face_ref[i]) = -1;
+        base_permutations[6 + 2 * face](start + i, start + i) = 0;
+        base_permutations[6 + 2 * face](start + i, start + face_rot[i]) = 1;
+        base_permutations[6 + 2 * face + 1](start + i, start + i) = 0;
+        base_permutations[6 + 2 * face + 1](start + i, start + face_ref[i]) = -1;
       }
     }
   }

--- a/cpp/raviart-thomas.cpp
+++ b/cpp/raviart-thomas.cpp
@@ -126,8 +126,8 @@ FiniteElement libtab::create_rt(cell::type celltype, int degree,
   }
   else if (tdim == 3)
   {
-    Eigen::ArrayXi face_ref = dofperms::triangle_reflection(degree - 1);
-    Eigen::ArrayXi face_rot = dofperms::triangle_rotation(degree - 1);
+    Eigen::ArrayXi face_ref = dofperms::triangle_reflection(degree);
+    Eigen::ArrayXi face_rot = dofperms::triangle_rotation(degree);
 
     for (int face = 0; face < facet_count; ++face)
     {

--- a/cpp/regge.cpp
+++ b/cpp/regge.cpp
@@ -131,7 +131,7 @@ FiniteElement libtab::create_regge(cell::type celltype, int degree,
 
   // TODO
   const int ndofs = dual.rows();
-  int perm_count = 0;
+  int perm_count = tdim == 2 ? 3 : 14;
   std::vector<Eigen::MatrixXd> base_permutations(
       perm_count, Eigen::MatrixXd::Identity(ndofs, ndofs));
 

--- a/cpp/regge.cpp
+++ b/cpp/regge.cpp
@@ -149,6 +149,6 @@ FiniteElement libtab::create_regge(cell::type celltype, int degree,
     entity_dofs[3] = {(degree + 1) * degree * (degree - 1)};
 
   return FiniteElement(name, celltype, degree, {tdim, tdim}, coeffs,
-                       entity_dofs, base_permutations, {});
+                       entity_dofs, base_permutations, {}, {}, "double covariant piola");
 }
 //-----------------------------------------------------------------------------

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -106,8 +106,10 @@ Each element has a `tabulate` function which returns the basis functions and a n
       .def_property_readonly("value_size", &FiniteElement::value_size)
       .def_property_readonly("value_shape", &FiniteElement::value_shape)
       .def_property_readonly("family_name", &FiniteElement::family_name)
+      .def_property_readonly("mapping_name", &FiniteElement::mapping_name)
       .def_property_readonly("points", &FiniteElement::points)
-      .def_property_readonly("interpolation_matrix", &FiniteElement::interpolation_matrix);
+      .def_property_readonly("interpolation_matrix",
+                             &FiniteElement::interpolation_matrix);
 
   // TODO: remove - not part of public interface
   // Create FiniteElement of different types

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -18,9 +18,12 @@ def test_interval_permutation_size(element_name, order):
 @pytest.mark.parametrize("element_name", [
     "Lagrange", "Discontinuous Lagrange",
     "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
-    "Raviart-Thomas", "Regge"])
+    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"])
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_triangle_permutation_size(element_name, order):
+    if element_name == "Crouzeix-Raviart" and order != 1:
+        pytest.xfail()
+
     e = libtab.create_element(element_name, "triangle", 1)
     assert len(e.base_permutations) == 3
 
@@ -28,8 +31,11 @@ def test_triangle_permutation_size(element_name, order):
 @pytest.mark.parametrize("element_name", [
     "Lagrange", "Discontinuous Lagrange",
     "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
-    "Raviart-Thomas", "Regge"])
+    "Raviart-Thomas", "Regge", "Crouzeix-Raviart"])
 @pytest.mark.parametrize("order", [1, 2, 3])
 def test_tetrahedron_permutation_size(element_name, order):
+    if element_name == "Crouzeix-Raviart" and order != 1:
+        pytest.xfail()
+
     e = libtab.create_element(element_name, "tetrahedron", 1)
     assert len(e.base_permutations) == 14

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 Matthew Scroggs
+# FEniCS Project
+# SPDX-License-Identifier: MIT
+
+import libtab
+import numpy
+import pytest
+
+
+@pytest.mark.parametrize("element_name", [
+    "Lagrange", "Discontinuous Lagrange"])
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_interval_permutation_size(element_name, order):
+    e = libtab.create_element(element_name, "interval", 1)
+    assert len(e.base_permutations) == 0
+
+
+@pytest.mark.parametrize("element_name", [
+    "Lagrange", "Discontinuous Lagrange",
+    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
+    "Raviart-Thomas", "Regge"])
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_triangle_permutation_size(element_name, order):
+    e = libtab.create_element(element_name, "triangle", 1)
+    assert len(e.base_permutations) == 3
+
+
+@pytest.mark.parametrize("element_name", [
+    "Lagrange", "Discontinuous Lagrange",
+    "Nedelec 1st kind H(curl)", "Nedelec 2nd kind H(curl)",
+    "Raviart-Thomas", "Regge"])
+@pytest.mark.parametrize("order", [1, 2, 3])
+def test_tetrahedron_permutation_size(element_name, order):
+    e = libtab.create_element(element_name, "tetrahedron", 1)
+    assert len(e.base_permutations) == 14

--- a/test/test_permutations.py
+++ b/test/test_permutations.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import libtab
-import numpy
 import pytest
 
 


### PR DESCRIPTION
- Progress on #15: this PR adds support for interpolation into low order Nedelec spaces. With these changes, interpolation into these spaces is working on dolfinx
- Added mapping_name to tell ffcx which mapping to use for the element
- Added test that permutations have the correct size.

Needs doing, but probably in a future PR:
- Simplify integral moments and interpolation generation (#79)